### PR TITLE
canaerospace: listen-only CANaerospace-in plugin (Rotax iS) per spec

### DIFF
--- a/doc/plugins/canaerospace.rst
+++ b/doc/plugins/canaerospace.rst
@@ -1,0 +1,141 @@
+====================
+CANaerospace Plugin
+====================
+
+A listen-only input bridge that decodes CANaerospace V1.7 frames from a
+CAN interface and writes mapped values into the FIX database.  The
+motivating device is the Rotax 912iS/915iS engine ECU, which broadcasts
+engine data as CANaerospace — this plugin gives any MakerPlane panel
+native Rotax engine instruments with no extra hardware beyond a CAN
+transceiver.
+
+CAN-FIX remains the system's native bus protocol.  CANaerospace is
+consumed here as a *federated input*: the plugin absorbs the protocol's
+self-describing message format once, at the gateway, so no other part of
+the stack has to speak it.  The plugin never transmits — not even Node
+Service replies — so its presence on an engine bus has zero bus impact.
+
+Requirements
+------------
+
+Only ``python-can`` (already a fix-gateway dependency).  The decode layer
+is implemented in the plugin itself; no third-party CANaerospace library
+is used.
+
+Configuration
+-------------
+
+::
+
+  # CANaerospace input bridge (e.g. Rotax 912iS / 915iS ECU)
+  canaerospace:
+    load: yes
+    module: fixgw.plugins.canaerospace
+    # python-can options. Bit rate is an interface-level concern:
+    # for socketcan set it with `ip link set can0 up type can bitrate ...`;
+    # for serial/slcan adapters see the python-can docs.
+    interface: socketcan
+    channel: can0
+    mapfile: "{CONFIG}/canaerospace/rotax_is_map.yaml"
+    # Seconds without a frame from a higher-priority node before a
+    # lower-priority node's data is accepted (dual-lane failover).
+    node_timeout: 2.0
+
+Mapfile
+-------
+
+The mapfile is the final authority on which CAN identifiers are decoded:
+any mapped canid in 0-2031 is accepted; the standard channel table
+(Emergency Event 0-127, Node Service 128-199/2000-2031, User-Defined
+200-299/1800-1899, Normal Operation 300-1799, Debug 1900-1999) only
+drives the default handling of *unmapped* traffic.
+
+::
+
+  ignore_fixid_missing: false
+  strict_types: false        # true drops frames whose wire type differs
+                             # from the mapfile's 'type' expectation
+
+  inputs:
+    - canid: 0x18C          # required, 0..2031
+      fixid: TACH1          # required, validated against the database
+      type: USHORT          # optional expectation check (see below)
+      element: 0            # optional, default 0; index into
+                            # multi-element types (SHORT2, UCHAR4, ...)
+      scale: 1.0            # optional; value*scale + offset
+      offset: 0.0
+      converter: none       # optional, applied AFTER scale/offset:
+                            #   k2c, c2f, kpa2inhg, kpa2psi,
+                            #   mps2knots, m2ft, pct (0..1 -> 0..100)
+      nodes: [16, 17]       # optional; allowed sender node-ids in
+                            # priority order. Absent = accept any sender.
+
+  events:                   # optional; Emergency Event channel (0..127)
+    - canid: 0x00
+      fixid: BTN1           # latched true when the event is seen
+      match_code: null      # optional; fire only when the 4-byte payload
+                            # equals this value
+
+Behavior notes:
+
+* **The wire's type byte is authoritative for decoding** (CANaerospace is
+  self-describing).  The mapfile ``type`` is an expectation check: a
+  mismatch increments the *Type Mismatches* counter and is still decoded,
+  unless ``strict_types: true``.  A device firmware update that changes a
+  parameter's type stays visible without silently corrupting values.
+* **Source-node priority** (``nodes:``): the Rotax dual-lane ECU can
+  broadcast the same parameters from both lanes.  A frame from a listed
+  node is written only when every higher-priority node has been quiet for
+  ``node_timeout`` seconds; senders not in the list are ignored.  This
+  prevents lane flip-flop on the panel.  There is no "lane failed"
+  annunciation — the FIX database ``tol`` mechanism already marks the
+  value *old* when both lanes go quiet.
+* **ERROR frames** mark the mapped fixid failed until the next good
+  value.  **NODATA** frames are counted and written nowhere.
+* **Emergency Event Data** (canid 0-127) is always logged at WARNING with
+  node-id and payload.  An ``events:`` entry latches ``True`` onto its
+  fixid; there is no auto-reset, because the sender's event is
+  edge-triggered — reset is the job of pilot/screen logic.
+* Message Code continuity is tracked per (canid, node) as a bus-health
+  telltale (*Sequence Gaps* in the plugin status); it never gates
+  decoding.
+
+Rotax iS bench verification
+---------------------------
+
+The shipped ``config/canaerospace/rotax_is_map.yaml`` is a skeleton with
+**every entry commented out**: the Rotax CAN identifiers are not
+published in this repository and none were invented.  To fill it in:
+
+1. Get the broadcast frame list (and the bus bit rate) from the BRP-Rotax
+   Installation Manual for the 912 iS / 915 iS, CAN bus appendix.
+2. Bench-capture from a real engine or ECU (``candump -ta can0``) and
+   correlate values against the cockpit display while varying RPM and
+   temperatures.
+3. Cross-check against open-source decoders (Kanardia / MGL protocol
+   notes).
+
+Uncomment an entry only after it passes a bench check.
+
+Simulator
+---------
+
+``fixgw.tools.canas_sim`` sends scripted CANaerospace frames onto any
+python-can interface for hardware-free development and desk demos::
+
+  # default demo script on a virtual bus
+  python -m fixgw.tools.canas_sim --interface virtual --channel tcan0
+
+  # custom script, 20 cycles/second
+  python -m fixgw.tools.canas_sim --script myscript.yaml --rate 20
+
+  # random hostile traffic (soak test)
+  python -m fixgw.tools.canas_sim --fuzz --duration 60
+
+Script format::
+
+  frames:
+    - canid: 0x12C
+      node: 16
+      type: USHORT
+      values: [2650]

--- a/src/fixgw/config/canaerospace/rotax_is_map.yaml
+++ b/src/fixgw/config/canaerospace/rotax_is_map.yaml
@@ -1,0 +1,65 @@
+# CANaerospace -> FIX mapping for the Rotax 912iS / 915iS engine ECU.
+#
+# SKELETON -- every mapping entry below is commented out ON PURPOSE.
+# The CAN identifiers used by the Rotax ECU are NOT published in this
+# repository and none have been invented here.  An entry may be
+# uncommented ONLY after it has passed a bench check against a real
+# engine or ECU.  The authoritative sources, in order:
+#
+#   1. The BRP-Rotax Installation Manual for the 912 iS / 915 iS, CAN bus
+#      appendix (available via the Rotax owner/OEM portal).  Also verify
+#      the bus BIT RATE there before bench day -- it is an `ip link`
+#      setting, not plugin configuration.
+#   2. A bench capture from a real engine or ECU (`candump -ta can0`),
+#      correlating values against the cockpit display while varying
+#      RPM / temperatures.
+#   3. Open-source decoders as cross-checks (Kanardia / MGL protocol
+#      notes, GitHub "Rotax 912iS CAN" projects).
+#
+# Fill in each entry's canid (and type/scale/converter as observed), test
+# it on the bench, then uncomment it.  The FIX key decisions below are
+# final -- they are the existing engine vocabulary in
+# src/fixgw/config/database/engine.yaml.
+#
+#   Rotax parameter        FIX key   notes
+#   ---------------------  --------  -------------------------------------
+#   Engine speed           TACH1     rpm, no converter expected
+#   Manifold pressure      MAP1      likely kPa or hPa -> kpa2inhg
+#   Oil pressure           OILP1     likely kPa -> kpa2psi
+#   Oil temperature        OILT1     likely K or degC -> k2c if needed
+#   Coolant temperature    H2OT1     as oil temperature
+#   EGT cylinder n         EGT1n     one entry per reported cylinder
+#   Throttle position      THR1      likely 0-1 or % (THR1 is 0-1; use
+#                                    scale, not pct, if the wire is %)
+#   Fuel pressure (915iS)  FUELP1    likely kPa -> kpa2psi
+#   System voltage         VOLT      volts
+#   Lane/status word       (none)    v1: visible in plugin status only;
+#                                    latching annunciator keys are a
+#                                    follow-up
+#
+# The Rotax dual-lane ECU broadcasts from two node-ids; once those are
+# known from the bench, list them in priority order on each entry, e.g.
+# `nodes: [<lane A>, <lane B>]`, and the plugin will fail over when the
+# preferred lane goes quiet for node_timeout seconds.
+
+ignore_fixid_missing: false
+strict_types: false
+
+inputs: []
+# Template for a bench-verified entry:
+#  - canid: 0x000          # from the Rotax manual or bench capture ONLY
+#    fixid: TACH1
+#    type: USHORT          # expectation check; the wire's type byte rules
+#    element: 0            # index into multi-element types (0-3)
+#    scale: 1.0            # value*scale + offset, then converter
+#    offset: 0.0
+#    converter: none       # none|k2c|c2f|kpa2inhg|kpa2psi|mps2knots|m2ft|pct
+#    nodes: [16, 17]       # allowed sender node-ids, priority order
+
+events: []
+# Emergency Event Data (canid 0-127) can latch an annunciator fixid.
+# The fixid stays true until reset by pilot/screen logic (the sender's
+# event is edge-triggered).
+#  - canid: 0x00
+#    fixid: BTN1
+#    match_code: null      # only fire when the 4-byte payload equals this

--- a/src/fixgw/config/connections/canaerospace.yaml
+++ b/src/fixgw/config/connections/canaerospace.yaml
@@ -1,0 +1,15 @@
+# CANaerospace input bridge (e.g. Rotax 912iS / 915iS engine ECU).
+# Listen-only: decodes CANaerospace V1.7 frames and writes mapped values
+# into the FIX database.  This plugin never transmits on the bus.
+canaerospace:
+  load: no
+  module: fixgw.plugins.canaerospace
+  # python-can options. Bit rate is an interface-level concern:
+  # for socketcan set it with `ip link set can0 up type can bitrate ...`;
+  # for serial/slcan adapters see the python-can documentation.
+  interface: socketcan
+  channel: can0
+  mapfile: "{CONFIG}/canaerospace/rotax_is_map.yaml"
+  # Seconds without a frame from a higher-priority node before a
+  # lower-priority node's data is accepted (dual-lane failover).
+  node_timeout: 2.0

--- a/src/fixgw/plugins/canaerospace/__init__.py
+++ b/src/fixgw/plugins/canaerospace/__init__.py
@@ -1,0 +1,201 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# CANaerospace input bridge.  A listen-only plugin that decodes
+# CANaerospace V1.7 frames (e.g. from a Rotax 912iS/915iS engine ECU) and
+# writes mapped values into the FIX database.  CAN-FIX remains the
+# system's native bus protocol; CANaerospace is consumed as a federated
+# input, never transmitted (not even Node Service replies).
+
+import threading
+import time
+from collections import OrderedDict
+
+import can
+
+import fixgw.plugin as plugin
+
+from . import mapping
+from . import protocol
+
+
+class MainThread(threading.Thread):
+    def __init__(self, parent, config):
+        super(MainThread, self).__init__()
+        self.getout = False
+        self.parent = parent
+        self.log = parent.log
+        self.mapping = parent.mapping
+        self.interesting = self.mapping.interesting
+        # last Message Code per (canid, node_id) for bus-health telltale
+        self._last_code = {}
+        self._warned_canids = set()
+
+    def _warn(self, canid, message):
+        if canid in self._warned_canids:
+            self.log.debug(message)
+        else:
+            self._warned_canids.add(canid)
+            self.log.warning(message)
+
+    def run(self):
+        self.bus = self.parent.bus
+
+        while True:
+            try:
+                msg = self.bus.recv(1.0)
+                if msg is not None:
+                    self.parent.recvcount += 1
+                    # Never let a bad frame kill the thread.
+                    try:
+                        self._process(msg)
+                    except Exception as e:
+                        self.parent.recvinvalidcount += 1
+                        self._warn(
+                            getattr(msg, "arbitration_id", -1),
+                            "Unexpected failure processing frame id {}: {}".format(
+                                getattr(msg, "arbitration_id", "?"), e
+                            ),
+                        )
+            finally:
+                if self.getout:
+                    break
+
+    def _process(self, msg):
+        canid = msg.arbitration_id
+        # 29-bit identifiers are legal CANaerospace but out of scope (the
+        # Rotax bus does not use them), as is anything past the standard
+        # 11-bit distribution.
+        if getattr(msg, "is_extended_id", False) or canid > protocol.MAX_CANID:
+            self.parent.recvignorecount += 1
+            return
+
+        channel = protocol.channel_for(canid)
+        mapped = self.interesting[canid]
+
+        if channel is protocol.Channel.EED:
+            # Emergency Event Data is always surfaced, mapped or not.
+            self.parent.emergencyeventcount += 1
+            data = bytes(msg.data)
+            node_id = data[0] if data else -1
+            self.log.warning(
+                "Emergency Event: canid={} node={} data={}".format(
+                    canid, node_id, data.hex()
+                )
+            )
+            raw_code = int.from_bytes(data[4:8], "big") if len(data) >= 8 else None
+            self.mapping.eventMap(canid, raw_code)
+            if not mapped:
+                return
+        elif not mapped:
+            # The mapfile is the final authority on which ids are decoded;
+            # the channel table only drives default handling for the rest.
+            self.parent.recvignorecount += 1
+            return
+
+        try:
+            cmsg = protocol.parse(canid, msg.data)
+        except protocol.CanasUnsupportedType:
+            self.parent.unsupportedtypecount += 1
+            return
+        except protocol.CanasDecodeError:
+            self.parent.recvinvalidcount += 1
+            return
+
+        self.parent.note_node(cmsg.node_id)
+
+        # Message Code continuity is a telltale only, never a gate.
+        key = (cmsg.canid, cmsg.node_id)
+        last = self._last_code.get(key)
+        if last is not None and cmsg.message_code != (last + 1) % 256:
+            self.parent.seqgapcount += 1
+        self._last_code[key] = cmsg.message_code
+
+        if cmsg.data_type == protocol.NODATA:
+            self.parent.nodatacount += 1
+            return
+
+        self.mapping.inputMap(cmsg)
+
+    def stop(self):
+        self.getout = True
+
+
+class Plugin(plugin.PluginBase):
+    def __init__(self, name, config, config_meta):
+        super(Plugin, self).__init__(name, config, config_meta)
+        self.interface = config["interface"]
+        self.channel = config["channel"]
+        self.node_timeout = float(config.get("node_timeout", 2.0))
+        mapfilename = config["mapfile"].format(CONFIG=config["CONFIGPATH"])
+        self.mapping = mapping.Mapping(mapfilename, self.log, self.node_timeout)
+        self.thread = MainThread(self, config)
+        self.recvcount = 0
+        self.recvignorecount = 0
+        self.recvinvalidcount = 0
+        self.unsupportedtypecount = 0
+        self.nodatacount = 0
+        self.seqgapcount = 0
+        self.emergencyeventcount = 0
+        self.nodes_seen = {}
+
+    def note_node(self, node_id):
+        d = self.nodes_seen.get(node_id)
+        if d is None:
+            self.nodes_seen[node_id] = {"frames": 1, "last_seen": time.monotonic()}
+        else:
+            d["frames"] += 1
+            d["last_seen"] = time.monotonic()
+
+    def run(self):
+        self.bus = can.ThreadSafeBus(self.channel, interface=self.interface)
+        self.thread.start()
+
+    def stop(self):
+        self.thread.stop()
+        if self.thread.is_alive():
+            try:
+                # Must wait longer than the can bus read
+                # in the main loop self.bus.recv(1.0)
+                self.thread.join(1.2)
+            except:
+                pass
+        if self.thread.is_alive():
+            raise plugin.PluginFail
+
+    def get_status(self):
+        x = OrderedDict()
+        x["CAN Interface"] = self.interface
+        x["CAN Channel"] = self.channel
+        x["Received Frames"] = self.recvcount
+        x["Decoded Writes"] = self.mapping.write_count
+        x["Ignored Frames"] = self.recvignorecount + self.mapping.recvignorecount
+        x["Invalid Frames"] = self.recvinvalidcount + self.mapping.recvinvalidcount
+        x["Type Mismatches"] = self.mapping.type_mismatch_count
+        x["Unsupported Types"] = self.unsupportedtypecount
+        x["Error Frames"] = self.mapping.error_frame_count
+        x["NoData Frames"] = self.nodatacount
+        x["Sequence Gaps"] = self.seqgapcount
+        x["Emergency Events"] = self.emergencyeventcount
+        now = time.monotonic()
+        x["Nodes Seen"] = {
+            node: {
+                "frames": d["frames"],
+                "last_seen_age_s": round(now - d["last_seen"], 1),
+            }
+            for node, d in self.nodes_seen.items()
+        }
+        return x

--- a/src/fixgw/plugins/canaerospace/mapping.py
+++ b/src/fixgw/plugins/canaerospace/mapping.py
@@ -1,0 +1,384 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# Maps decoded CANaerospace messages onto FIX database keys.  Follows the
+# closure pattern of fixgw.plugins.canfix.mapping: database items are
+# resolved once at load time and the hot path is dictionary lookups only.
+
+import os
+import time
+
+import fixgw.database as database
+from fixgw import cfg
+
+from . import protocol
+
+# Named unit converters, applied AFTER scale/offset.
+CONVERTERS = {
+    "none": lambda v: v,
+    "k2c": lambda v: v - 273.15,
+    "c2f": lambda v: v * 9.0 / 5.0 + 32.0,
+    "kpa2inhg": lambda v: v * 0.2953,
+    "kpa2psi": lambda v: v * 0.14503773773,
+    "mps2knots": lambda v: v * 1.94384449,
+    "m2ft": lambda v: v * 3.28083989501,
+    "pct": lambda v: v * 100.0,
+}
+
+_KNOWN_TOP_KEYS = {"ignore_fixid_missing", "strict_types", "inputs", "events"}
+
+
+class Mapping(object):
+    def __init__(self, mapfile, log=None, node_timeout=2.0):
+        self.log = log
+        self.node_timeout = node_timeout
+        self.ignore_fixid_missing = False
+        self.strict_types = False
+
+        # counters surfaced through the plugin's get_status()
+        self.write_count = 0
+        self.recvignorecount = 0
+        self.recvinvalidcount = 0
+        self.type_mismatch_count = 0
+        self.error_frame_count = 0
+        self.event_count = 0
+
+        # canid -> {element -> entry}; also a flat boolean list for the
+        # hot-path reject, exactly like canfix's 'interesting' array.
+        self.input_map = {}
+        self.event_map = {}
+        self.interesting = [False] * 2048
+
+        self._warned_canids = set()
+
+        if not os.path.exists(mapfile):
+            raise ValueError("Unable to open mapfile: '{}'".format(mapfile))
+        maps, meta = cfg.from_yaml(mapfile, metadata=True)
+
+        for key, attr in (
+            ("ignore_fixid_missing", "ignore_fixid_missing"),
+            ("strict_types", "strict_types"),
+        ):
+            if key in maps:
+                if isinstance(maps[key], bool):
+                    setattr(self, attr, maps[key])
+                else:
+                    raise ValueError(
+                        cfg.message(
+                            "{} must be true or false".format(key), meta, key, True
+                        )
+                    )
+
+        for key in maps:
+            if key not in _KNOWN_TOP_KEYS and self.log:
+                self.log.warning(
+                    "Unknown top-level key '{}' in mapfile '{}' ignored".format(
+                        key, mapfile
+                    )
+                )
+
+        inputs = maps.get("inputs") or []
+        meta_inputs = meta.get("inputs", {})
+        for index, each in enumerate(inputs):
+            entry = self._validate_input(each, meta_inputs, index)
+            if entry is None:
+                continue  # missing fixid with ignore_fixid_missing: true
+            elements = self.input_map.setdefault(entry["canid"], {})
+            if entry["element"] in elements:
+                raise ValueError(
+                    cfg.message(
+                        "duplicate (canid, element) pair ({}, {})".format(
+                            entry["canid"], entry["element"]
+                        ),
+                        meta_inputs[index],
+                        "canid",
+                        True,
+                    )
+                )
+            elements[entry["element"]] = entry
+            self.interesting[entry["canid"]] = True
+
+        events = maps.get("events") or []
+        meta_events = meta.get("events", {})
+        for index, each in enumerate(events):
+            entry = self._validate_event(each, meta_events, index)
+            if entry is None:
+                continue
+            if entry["canid"] in self.event_map:
+                raise ValueError(
+                    cfg.message(
+                        "duplicate event canid {}".format(entry["canid"]),
+                        meta_events[index],
+                        "canid",
+                        True,
+                    )
+                )
+            self.event_map[entry["canid"]] = entry
+
+    def _resolve_item(self, fixid):
+        try:
+            return database.get_raw_item(fixid)
+        except KeyError:
+            # Validation already rejected unknown fixids unless
+            # ignore_fixid_missing is set, so this entry is simply inert.
+            return None
+
+    def _validate_input(self, data, meta, index):
+        if not isinstance(data, dict):
+            raise ValueError(cfg.message("Inputs should be dictionaries", meta, index))
+        for k in ["canid", "fixid"]:
+            if k not in data:
+                raise ValueError(
+                    cfg.message("Key '{}' is missing".format(k), meta, index)
+                )
+        canid = data["canid"]
+        if not isinstance(canid, int) or canid < 0 or canid > protocol.MAX_CANID:
+            raise ValueError(
+                cfg.message(
+                    "canid must be an integer 0-{}".format(protocol.MAX_CANID),
+                    meta[index],
+                    "canid",
+                    True,
+                )
+            )
+        if data["fixid"] not in database.listkeys() and not self.ignore_fixid_missing:
+            raise ValueError(
+                cfg.message(
+                    "fixid '{}' is not a valid fixid".format(data["fixid"]),
+                    meta[index],
+                    "fixid",
+                    True,
+                )
+            )
+        type_code = None
+        if "type" in data:
+            if data["type"] not in protocol.TYPE_CODES:
+                raise ValueError(
+                    cfg.message(
+                        "type '{}' is not a supported CANaerospace data type".format(
+                            data["type"]
+                        ),
+                        meta[index],
+                        "type",
+                        True,
+                    )
+                )
+            type_code = protocol.TYPE_CODES[data["type"]]
+        element = data.get("element", 0)
+        if not isinstance(element, int) or element < 0 or element > 3:
+            raise ValueError(
+                cfg.message(
+                    "element must be an integer 0-3", meta[index], "element", True
+                )
+            )
+        for k in ("scale", "offset"):
+            if k in data and not isinstance(data[k], (int, float)):
+                raise ValueError(
+                    cfg.message("{} must be a number".format(k), meta[index], k, True)
+                )
+        converter = data.get("converter", "none")
+        if converter not in CONVERTERS:
+            raise ValueError(
+                cfg.message(
+                    "converter '{}' unknown; choose from {}".format(
+                        converter, ", ".join(sorted(CONVERTERS))
+                    ),
+                    meta[index],
+                    "converter",
+                    True,
+                )
+            )
+        nodes = data.get("nodes")
+        if nodes is not None:
+            if (
+                not isinstance(nodes, list)
+                or not nodes
+                or not all(isinstance(n, int) and 0 <= n <= 255 for n in nodes)
+            ):
+                raise ValueError(
+                    cfg.message(
+                        "nodes must be a non-empty list of node ids 0-255",
+                        meta[index],
+                        "nodes",
+                        True,
+                    )
+                )
+        item = self._resolve_item(data["fixid"])
+        if item is None:
+            return None
+        return {
+            "canid": canid,
+            "fixid": data["fixid"],
+            "item": item,
+            "element": element,
+            "type_code": type_code,
+            "scale": float(data.get("scale", 1.0)),
+            "offset": float(data.get("offset", 0.0)),
+            "converter": CONVERTERS[converter],
+            "nodes": nodes,
+            "last_seen": {},
+        }
+
+    def _validate_event(self, data, meta, index):
+        if not isinstance(data, dict):
+            raise ValueError(cfg.message("Events should be dictionaries", meta, index))
+        for k in ["canid", "fixid"]:
+            if k not in data:
+                raise ValueError(
+                    cfg.message("Key '{}' is missing".format(k), meta, index)
+                )
+        canid = data["canid"]
+        if not isinstance(canid, int) or canid < 0 or canid > 127:
+            raise ValueError(
+                cfg.message(
+                    "event canid must be in the Emergency Event range 0-127",
+                    meta[index],
+                    "canid",
+                    True,
+                )
+            )
+        if data["fixid"] not in database.listkeys() and not self.ignore_fixid_missing:
+            raise ValueError(
+                cfg.message(
+                    "fixid '{}' is not a valid fixid".format(data["fixid"]),
+                    meta[index],
+                    "fixid",
+                    True,
+                )
+            )
+        match_code = data.get("match_code")
+        if match_code is not None and not isinstance(match_code, int):
+            raise ValueError(
+                cfg.message(
+                    "match_code must be an integer or null",
+                    meta[index],
+                    "match_code",
+                    True,
+                )
+            )
+        item = self._resolve_item(data["fixid"])
+        if item is None:
+            return None
+        return {
+            "canid": canid,
+            "fixid": data["fixid"],
+            "item": item,
+            "match_code": match_code,
+        }
+
+    def _warn(self, canid, message):
+        """First occurrence per canid at WARNING, subsequent at DEBUG."""
+        if self.log is None:
+            return
+        if canid in self._warned_canids:
+            self.log.debug(message)
+        else:
+            self._warned_canids.add(canid)
+            self.log.warning(message)
+
+    def inputMap(self, msg):
+        """Write a decoded CanasMessage into the mapped FIX items."""
+        elements = self.input_map.get(msg.canid)
+        if elements is None:
+            self.recvignorecount += 1
+            return
+        now = time.monotonic()
+        for element, entry in elements.items():
+            item = entry["item"]
+
+            # Source-node filter and lane priority (Rotax lane A / lane B):
+            # record the sender as alive, then accept only if every
+            # higher-priority node has been quiet for node_timeout.
+            nodes = entry["nodes"]
+            if nodes is not None:
+                if msg.node_id not in nodes:
+                    self.recvignorecount += 1
+                    continue
+                entry["last_seen"][msg.node_id] = now
+                blocked = False
+                for higher in nodes[: nodes.index(msg.node_id)]:
+                    seen = entry["last_seen"].get(higher)
+                    if seen is not None and (now - seen) <= self.node_timeout:
+                        blocked = True
+                        break
+                if blocked:
+                    self.recvignorecount += 1
+                    continue
+
+            if msg.data_type == protocol.ERROR:
+                # Mark the element-0 mapping failed until the next good
+                # value; ERROR frames carry no element addressing.
+                if element == 0:
+                    self.error_frame_count += 1
+                    self._warn(
+                        msg.canid,
+                        "ERROR frame on canid {} (code 0x{:08X}); marking {} failed".format(
+                            msg.canid, msg.values[0], entry["fixid"]
+                        ),
+                    )
+                    item.fail = True
+                continue
+
+            # The wire's type byte is authoritative for decoding; the
+            # mapfile 'type' is an expectation check only (unless
+            # strict_types drops mismatches).
+            if entry["type_code"] is not None and msg.data_type != entry["type_code"]:
+                self.type_mismatch_count += 1
+                self._warn(
+                    msg.canid,
+                    "canid {} arrived as {} but the mapfile expects {}".format(
+                        msg.canid,
+                        protocol.type_name(msg.data_type),
+                        protocol.type_name(entry["type_code"]),
+                    ),
+                )
+                if self.strict_types:
+                    continue
+
+            if element >= len(msg.values):
+                self.recvinvalidcount += 1
+                continue
+
+            value = msg.values[element] * entry["scale"] + entry["offset"]
+            value = entry["converter"](value)
+            try:
+                if item.fail:
+                    item.fail = False
+                item.value = value
+                self.write_count += 1
+            except ValueError:
+                self.recvinvalidcount += 1
+                if self.log:
+                    self.log.debug(
+                        "Database rejected {} = {}".format(entry["fixid"], value)
+                    )
+
+    def eventMap(self, canid, raw_code):
+        """Latch an Emergency Event onto its mapped annunciator fixid.
+
+        raw_code is the 4 payload bytes as an unsigned big-endian int, or
+        None when the frame carried no 4-byte payload.
+        """
+        entry = self.event_map.get(canid)
+        if entry is None:
+            return
+        if entry["match_code"] is not None and raw_code != entry["match_code"]:
+            return
+        try:
+            entry["item"].value = True
+            self.event_count += 1
+        except ValueError:
+            self.recvinvalidcount += 1

--- a/src/fixgw/plugins/canaerospace/protocol.py
+++ b/src/fixgw/plugins/canaerospace/protocol.py
@@ -1,0 +1,257 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# Pure CANaerospace V1.7 frame decoding.  No fixgw imports, stdlib only,
+# so this module can be unit-tested against hex vectors and reused by the
+# canas_sim tool.
+#
+# Authoritative source: CANaerospace Interface Specification V1.7
+# (canas_17.pdf, Stock Flight Systems).  Both tables below (data types and
+# identifier distribution) were cross-verified line-by-line against the
+# CanasStandardDataTypeID and CanasMessageTypeID enums in Pavel Kirienko's
+# reference C implementation (canaerospace/message.h), which transcribes
+# the same tables from the PDF.
+
+import struct
+from dataclasses import dataclass
+from enum import Enum
+
+
+class CanasDecodeError(ValueError):
+    """The frame is not a decodable CANaerospace message."""
+
+
+class CanasUnsupportedType(CanasDecodeError):
+    """The frame's Data Type is legal CANaerospace but not implemented."""
+
+
+# Highest standard 11-bit CANaerospace identifier (Node Service Low ends
+# at 2031; 2032-2047 are outside the V1.7 distribution).
+MAX_CANID = 2031
+
+
+class Channel(Enum):
+    EED = "Emergency Event Data"
+    NSH = "Node Service High"
+    UDH = "User-Defined High"
+    NOD = "Normal Operation Data"
+    UDL = "User-Defined Low"
+    DSD = "Debug Service Data"
+    NSL = "Node Service Low"
+
+
+# CANaerospace V1.7 standard identifier distribution (11-bit).
+# (canid_low, canid_high, channel)
+CHANNEL_RANGES = (
+    (0, 127, Channel.EED),
+    (128, 199, Channel.NSH),
+    (200, 299, Channel.UDH),
+    (300, 1799, Channel.NOD),
+    (1800, 1899, Channel.UDL),
+    (1900, 1999, Channel.DSD),
+    (2000, 2031, Channel.NSL),
+)
+
+
+def channel_for(canid):
+    for low, high, channel in CHANNEL_RANGES:
+        if low <= canid <= high:
+            return channel
+    raise CanasDecodeError(
+        "CAN id {} outside the CANaerospace 11-bit distribution (0-{})".format(
+            canid, MAX_CANID
+        )
+    )
+
+
+# CANaerospace V1.7 standard data types (message byte 1).  Codes are
+# sequential from 0 in the order the specification lists them.
+NODATA = 0
+ERROR = 1
+FLOAT = 2
+LONG = 3
+ULONG = 4
+BLONG = 5
+SHORT = 6
+USHORT = 7
+BSHORT = 8
+CHAR = 9
+UCHAR = 10
+BCHAR = 11
+SHORT2 = 12
+USHORT2 = 13
+BSHORT2 = 14
+CHAR4 = 15
+UCHAR4 = 16
+BCHAR4 = 17
+CHAR2 = 18
+UCHAR2 = 19
+BCHAR2 = 20
+MEMID = 21
+CHKSUM = 22
+ACHAR = 23
+ACHAR2 = 24
+ACHAR4 = 25
+CHAR3 = 26
+UCHAR3 = 27
+BCHAR3 = 28
+ACHAR3 = 29
+DOUBLEH = 30
+DOUBLEL = 31
+
+# Implemented (decodable) types: code -> (name, big-endian struct format).
+# All CANaerospace data is big-endian.  Bitfield types (B*) are delivered
+# as unsigned ints; multi-element types unpack to multiple values addressed
+# by the mapfile's 'element'.
+_DECODERS = {
+    NODATA: ("NODATA", ""),
+    ERROR: ("ERROR", ">I"),
+    FLOAT: ("FLOAT", ">f"),
+    LONG: ("LONG", ">i"),
+    ULONG: ("ULONG", ">I"),
+    BLONG: ("BLONG", ">I"),
+    SHORT: ("SHORT", ">h"),
+    USHORT: ("USHORT", ">H"),
+    BSHORT: ("BSHORT", ">H"),
+    CHAR: ("CHAR", ">b"),
+    UCHAR: ("UCHAR", ">B"),
+    BCHAR: ("BCHAR", ">B"),
+    SHORT2: ("SHORT2", ">hh"),
+    USHORT2: ("USHORT2", ">HH"),
+    BSHORT2: ("BSHORT2", ">HH"),
+    CHAR4: ("CHAR4", ">bbbb"),
+    UCHAR4: ("UCHAR4", ">BBBB"),
+    BCHAR4: ("BCHAR4", ">BBBB"),
+    CHAR2: ("CHAR2", ">bb"),
+    UCHAR2: ("UCHAR2", ">BB"),
+    BCHAR2: ("BCHAR2", ">BB"),
+    CHAR3: ("CHAR3", ">bbb"),
+    UCHAR3: ("UCHAR3", ">BBB"),
+    BCHAR3: ("BCHAR3", ">BBB"),
+}
+
+# Legal-but-unimplemented codes, for error messages and status readability.
+_UNSUPPORTED_NAMES = {
+    MEMID: "MEMID",
+    CHKSUM: "CHKSUM",
+    ACHAR: "ACHAR",
+    ACHAR2: "ACHAR2",
+    ACHAR4: "ACHAR4",
+    ACHAR3: "ACHAR3",
+    DOUBLEH: "DOUBLEH",
+    DOUBLEL: "DOUBLEL",
+}
+
+# Mapfile 'type:' vocabulary: name -> code, implemented types only.
+TYPE_CODES = {name: code for code, (name, _fmt) in _DECODERS.items()}
+
+
+def type_name(code):
+    if code in _DECODERS:
+        return _DECODERS[code][0]
+    if code in _UNSUPPORTED_NAMES:
+        return _UNSUPPORTED_NAMES[code]
+    if 100 <= code <= 255:
+        return "UDEF{}".format(code)
+    return "RESERVED{}".format(code)
+
+
+@dataclass(frozen=True)
+class CanasMessage:
+    canid: int
+    node_id: int
+    data_type: int
+    service_code: int
+    message_code: int
+    values: tuple
+    channel: Channel
+
+
+def parse(arbitration_id, data):
+    """Decode one CANaerospace frame into a CanasMessage.
+
+    Raises CanasUnsupportedType for legal-but-unimplemented data types and
+    CanasDecodeError for anything that is not a well-formed message.
+    """
+    if arbitration_id < 0 or arbitration_id > MAX_CANID:
+        raise CanasDecodeError(
+            "CAN id {} outside CANaerospace range 0-{}".format(
+                arbitration_id, MAX_CANID
+            )
+        )
+    data = bytes(data)
+    # Every CANaerospace message carries the 4-byte header (Node-ID,
+    # Data Type, Service Code, Message Code) plus 0-4 data bytes.
+    if len(data) < 4 or len(data) > 8:
+        raise CanasDecodeError(
+            "DLC {} invalid; CANaerospace messages are 4-8 bytes".format(len(data))
+        )
+    node_id = data[0]
+    data_type = data[1]
+    service_code = data[2]
+    message_code = data[3]
+    payload = data[4:]
+
+    try:
+        name, fmt = _DECODERS[data_type]
+    except KeyError:
+        raise CanasUnsupportedType(
+            "unsupported data type {} ({})".format(data_type, type_name(data_type))
+        )
+    expected = struct.calcsize(fmt) if fmt else 0
+    if len(payload) != expected:
+        raise CanasDecodeError(
+            "{} payload is {} bytes, expected {}".format(name, len(payload), expected)
+        )
+    values = struct.unpack(fmt, payload) if fmt else ()
+    return CanasMessage(
+        canid=arbitration_id,
+        node_id=node_id,
+        data_type=data_type,
+        service_code=service_code,
+        message_code=message_code,
+        values=values,
+        channel=channel_for(arbitration_id),
+    )
+
+
+def build(msg):
+    """Inverse of parse(): return (arbitration_id, data bytes).
+
+    Used by the canas_sim tool and the round-trip decode tests.
+    """
+    if msg.canid < 0 or msg.canid > MAX_CANID:
+        raise CanasDecodeError(
+            "CAN id {} outside CANaerospace range 0-{}".format(msg.canid, MAX_CANID)
+        )
+    try:
+        name, fmt = _DECODERS[msg.data_type]
+    except KeyError:
+        raise CanasUnsupportedType(
+            "unsupported data type {} ({})".format(
+                msg.data_type, type_name(msg.data_type)
+            )
+        )
+    header = bytes(
+        (msg.node_id & 0xFF, msg.data_type, msg.service_code, msg.message_code & 0xFF)
+    )
+    try:
+        payload = struct.pack(fmt, *msg.values) if fmt else b""
+    except struct.error as e:
+        raise CanasDecodeError(
+            "cannot encode {} values {}: {}".format(name, msg.values, e)
+        )
+    return msg.canid, header + payload

--- a/src/fixgw/tools/canas_sim.py
+++ b/src/fixgw/tools/canas_sim.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+"""CANaerospace bus simulator.
+
+Sends scripted CANaerospace frames onto any python-can interface so the
+canaerospace plugin can be developed and demonstrated with no hardware:
+
+    python -m fixgw.tools.canas_sim --interface virtual --channel tcan0
+    python -m fixgw.tools.canas_sim --script myscript.yaml --rate 20
+    python -m fixgw.tools.canas_sim --fuzz --duration 60
+
+Script files are YAML:
+
+    frames:
+      - canid: 0x12C
+        node: 16
+        type: USHORT       # any implemented CANaerospace data type name
+        values: [2650]
+        service_code: 0    # optional, default 0
+
+Each listed frame is sent once per cycle at --rate cycles per second, with
+a per-(canid, node) Message Code that increments and wraps at 255 like a
+real CANaerospace sender.
+
+The default script drives the FIX keys the Rotax mapfile skeleton targets
+(TACH1, MAP1, OILP1, ...) using PLACEHOLDER canids in the User-Defined
+High range -- they are demo values for desk work against a matching test
+mapfile, NOT verified Rotax identifiers (see
+src/fixgw/config/canaerospace/rotax_is_map.yaml for the verification
+procedure).
+
+--fuzz mode sends uniformly random frames (random ids, DLCs and payload
+bytes) instead of the script; it exists to soak-test that hostile traffic
+never kills the plugin thread.
+"""
+
+import argparse
+import random
+import time
+
+import can
+import yaml
+
+from fixgw.plugins.canaerospace import protocol
+
+# Demo placeholders in the User-Defined High range (200-299), NOT Rotax ids.
+DEFAULT_SCRIPT = [
+    {"canid": 0xC8, "node": 16, "type": "USHORT", "values": [2650]},  # TACH1-ish rpm
+    {"canid": 0xC9, "node": 16, "type": "FLOAT", "values": [95.0]},  # MAP1-ish kPa
+    {"canid": 0xCA, "node": 16, "type": "FLOAT", "values": [310.0]},  # OILP1-ish kPa
+    {"canid": 0xCB, "node": 16, "type": "FLOAT", "values": [363.15]},  # OILT1-ish K
+    {"canid": 0xCC, "node": 16, "type": "FLOAT", "values": [355.15]},  # H2OT1-ish K
+    {"canid": 0xCD, "node": 16, "type": "UCHAR4", "values": [78, 80, 79, 81]},  # EGT/10
+    {"canid": 0xCE, "node": 16, "type": "FLOAT", "values": [13.9]},  # VOLT
+]
+
+
+def load_script(path):
+    with open(path) as f:
+        doc = yaml.safe_load(f)
+    frames = doc.get("frames") if isinstance(doc, dict) else None
+    if not frames:
+        raise SystemExit("Script '{}' has no 'frames' list".format(path))
+    return frames
+
+
+def script_messages(frames, message_codes):
+    """Yield (arbitration_id, data) for one cycle of the script."""
+    for frame in frames:
+        canid = frame["canid"]
+        node = frame.get("node", 0)
+        try:
+            data_type = protocol.TYPE_CODES[frame["type"]]
+        except KeyError:
+            raise SystemExit(
+                "Frame canid {}: unknown data type '{}'".format(
+                    canid, frame.get("type")
+                )
+            )
+        key = (canid, node)
+        code = message_codes.get(key, -1)
+        code = (code + 1) % 256
+        message_codes[key] = code
+        msg = protocol.CanasMessage(
+            canid=canid,
+            node_id=node,
+            data_type=data_type,
+            service_code=frame.get("service_code", 0),
+            message_code=code,
+            values=tuple(frame.get("values", ())),
+            channel=protocol.channel_for(canid),
+        )
+        yield protocol.build(msg)
+
+
+def fuzz_message(rng):
+    canid = rng.randrange(0, protocol.MAX_CANID + 1)
+    data = bytes(rng.randrange(256) for _ in range(rng.randrange(0, 9)))
+    return canid, data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Send scripted or random CANaerospace frames onto a CAN bus"
+    )
+    parser.add_argument("--interface", default="virtual", help="python-can interface")
+    parser.add_argument("--channel", default="tcan0", help="python-can channel")
+    parser.add_argument("--script", help="YAML frame script (default: built-in demo)")
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=10.0,
+        help="script cycles (or fuzz frames) per second",
+    )
+    parser.add_argument(
+        "--duration", type=float, default=0.0, help="seconds to run (0 = forever)"
+    )
+    parser.add_argument(
+        "--fuzz", action="store_true", help="send random frames instead of the script"
+    )
+    parser.add_argument("--seed", type=int, default=None, help="fuzz RNG seed")
+    args = parser.parse_args()
+
+    frames = load_script(args.script) if args.script else DEFAULT_SCRIPT
+    rng = random.Random(args.seed)
+    message_codes = {}
+    period = 1.0 / args.rate if args.rate > 0 else 0.1
+
+    bus = can.Bus(args.channel, interface=args.interface)
+    start = time.monotonic()
+    sent = 0
+    try:
+        while True:
+            if args.fuzz:
+                canid, data = fuzz_message(rng)
+                bus.send(
+                    can.Message(arbitration_id=canid, data=data, is_extended_id=False)
+                )
+                sent += 1
+            else:
+                for canid, data in script_messages(frames, message_codes):
+                    bus.send(
+                        can.Message(
+                            arbitration_id=canid, data=data, is_extended_id=False
+                        )
+                    )
+                    sent += 1
+            time.sleep(period)
+            if args.duration and (time.monotonic() - start) >= args.duration:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        bus.shutdown()
+    print("sent {} frames in {:.1f}s".format(sent, time.monotonic() - start))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config/canaerospace/map.yaml
+++ b/tests/config/canaerospace/map.yaml
@@ -1,0 +1,41 @@
+# CANaerospace test mapfile.  Canids here are arbitrary test values in the
+# User-Defined High (200-299) and Normal Operation (300-1799) ranges; they
+# do not represent any real device.
+ignore_fixid_missing: false
+strict_types: false
+
+inputs:
+  - canid: 200          # 0xC8
+    fixid: TACH1
+    type: USHORT
+  - canid: 201
+    fixid: OILP1
+    type: FLOAT
+    converter: kpa2psi
+  - canid: 202
+    fixid: OILT1
+    type: FLOAT
+    converter: k2c
+    nodes: [16, 17]
+  - canid: 205          # one UCHAR4 frame feeds two cylinders
+    fixid: EGT11
+    type: UCHAR4
+    element: 0
+    scale: 10.0
+  - canid: 205
+    fixid: EGT12
+    type: UCHAR4
+    element: 1
+    scale: 10.0
+  - canid: 300
+    fixid: H2OT1
+    type: SHORT
+    scale: 0.1
+
+events:
+  - canid: 16
+    fixid: BTN1
+    match_code: null
+  - canid: 17
+    fixid: BTN2
+    match_code: 305419896   # 0x12345678

--- a/tests/plugins/canaerospace/test_mapping.py
+++ b/tests/plugins/canaerospace/test_mapping.py
@@ -1,0 +1,411 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# Unit tests for the CANaerospace mapfile loader and the decoded-message
+# to FIX-database dispatch (scale/offset/converters, node priority,
+# strict_types, ERROR flagging, validation errors).
+
+import pytest
+
+import fixgw.plugins.canaerospace.mapping as canas_mapping
+from fixgw.plugins.canaerospace import protocol
+
+
+class FakeLog:
+    def __init__(self):
+        self.debugs = []
+        self.warnings = []
+
+    def debug(self, message):
+        self.debugs.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+def make_mapfile(tmp_path, text):
+    p = tmp_path / "map.yaml"
+    p.write_text(text)
+    return str(p)
+
+
+def make_mapping(tmp_path, text, log=None, node_timeout=2.0):
+    return canas_mapping.Mapping(
+        make_mapfile(tmp_path, text), log or FakeLog(), node_timeout
+    )
+
+
+def msg(canid, dtype, values, node=16, code=0):
+    return protocol.CanasMessage(
+        canid=canid,
+        node_id=node,
+        data_type=dtype,
+        service_code=0,
+        message_code=code,
+        values=tuple(values),
+        channel=protocol.channel_for(canid),
+    )
+
+
+def test_scale_offset_write(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    scale: 0.5
+    offset: 100.0
+""",
+    )
+    m.inputMap(msg(300, protocol.USHORT, [1000]))
+    assert database.read("TACH1")[0] == 600
+    assert m.write_count == 1
+    assert m.interesting[300] is True
+    assert m.interesting[301] is False
+
+
+def test_converters(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: OILT1
+    converter: k2c
+  - canid: 301
+    fixid: OILP1
+    converter: kpa2psi
+  - canid: 302
+    fixid: H2OT1
+    converter: pct
+""",
+    )
+    m.inputMap(msg(300, protocol.FLOAT, [373.15]))
+    m.inputMap(msg(301, protocol.FLOAT, [300.0]))
+    m.inputMap(msg(302, protocol.FLOAT, [0.85]))
+    assert database.read("OILT1")[0] == pytest.approx(100.0, abs=0.01)
+    assert database.read("OILP1")[0] == pytest.approx(43.51, abs=0.01)
+    assert database.read("H2OT1")[0] == pytest.approx(85.0, abs=0.01)
+
+
+def test_multi_element_frame_feeds_multiple_fixids(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: EGT11
+    element: 0
+    scale: 10.0
+  - canid: 300
+    fixid: EGT12
+    element: 1
+    scale: 10.0
+""",
+    )
+    m.inputMap(msg(300, protocol.UCHAR4, [78, 80, 0, 0]))
+    assert database.read("EGT11")[0] == pytest.approx(780.0)
+    assert database.read("EGT12")[0] == pytest.approx(800.0)
+    assert m.write_count == 2
+
+
+def test_element_beyond_frame_values(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: EGT13
+    element: 2
+""",
+    )
+    # USHORT only carries one value; element 2 cannot be extracted
+    m.inputMap(msg(300, protocol.USHORT, [500]))
+    assert m.recvinvalidcount == 1
+    assert m.write_count == 0
+
+
+def test_node_priority_failover(tmp_path, database, monkeypatch):
+    now = {"t": 1000.0}
+    monkeypatch.setattr(canas_mapping.time, "monotonic", lambda: now["t"])
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: OILT1
+    nodes: [16, 17]
+""",
+        node_timeout=2.0,
+    )
+    # Lane B accepted while lane A has never been seen
+    m.inputMap(msg(300, protocol.FLOAT, [50.0], node=17))
+    assert database.read("OILT1")[0] == pytest.approx(50.0)
+    # Lane A takes over
+    m.inputMap(msg(300, protocol.FLOAT, [60.0], node=16))
+    assert database.read("OILT1")[0] == pytest.approx(60.0)
+    # Lane B blocked while lane A is fresh
+    now["t"] += 1.0
+    m.inputMap(msg(300, protocol.FLOAT, [70.0], node=17))
+    assert database.read("OILT1")[0] == pytest.approx(60.0)
+    assert m.recvignorecount == 1
+    # Lane A stale -> lane B accepted again
+    now["t"] += 2.1
+    m.inputMap(msg(300, protocol.FLOAT, [80.0], node=17))
+    assert database.read("OILT1")[0] == pytest.approx(80.0)
+    # A sender not in the list is ignored
+    m.inputMap(msg(300, protocol.FLOAT, [90.0], node=99))
+    assert database.read("OILT1")[0] == pytest.approx(80.0)
+    assert m.recvignorecount == 2
+
+
+def test_type_mismatch_counted_but_decoded(tmp_path, database):
+    log = FakeLog()
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    type: USHORT
+""",
+        log=log,
+    )
+    # Wire says SHORT, mapfile expects USHORT: counted, still decoded
+    m.inputMap(msg(300, protocol.SHORT, [2650]))
+    assert m.type_mismatch_count == 1
+    assert database.read("TACH1")[0] == 2650
+    assert len(log.warnings) == 1
+    # Second mismatch on the same canid is rate-limited to debug
+    m.inputMap(msg(300, protocol.SHORT, [2700]))
+    assert len(log.warnings) == 1
+    assert m.type_mismatch_count == 2
+
+
+def test_strict_types_drops_mismatch(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+strict_types: true
+inputs:
+  - canid: 300
+    fixid: TACH1
+    type: USHORT
+""",
+    )
+    m.inputMap(msg(300, protocol.SHORT, [2650]))
+    assert m.type_mismatch_count == 1
+    assert m.write_count == 0
+    assert database.read("TACH1")[0] == 0
+
+
+def test_error_frame_sets_fail_until_next_good_value(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: OILP1
+""",
+    )
+    m.inputMap(msg(300, protocol.ERROR, [0xDEADBEEF]))
+    # value tuple: (value, annunciate, old, bad, fail, secfail)
+    assert database.read("OILP1")[4] is True
+    assert m.error_frame_count == 1
+    m.inputMap(msg(300, protocol.FLOAT, [55.0]))
+    assert database.read("OILP1")[0] == pytest.approx(55.0)
+    assert database.read("OILP1")[4] is False
+
+
+def test_events(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+events:
+  - canid: 16
+    fixid: BTN1
+    match_code: null
+  - canid: 17
+    fixid: BTN2
+    match_code: 305419896
+""",
+    )
+    assert database.read("BTN1")[0] is False
+    m.eventMap(16, 1)
+    assert database.read("BTN1")[0] is True
+    assert m.event_count == 1
+    # match_code mismatch does not fire
+    m.eventMap(17, 0x11111111)
+    assert database.read("BTN2")[0] is False
+    m.eventMap(17, 0x12345678)
+    assert database.read("BTN2")[0] is True
+    # unmapped event canid is a no-op
+    m.eventMap(99, None)
+
+
+def test_unmapped_canid_ignored(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+""",
+    )
+    m.inputMap(msg(301, protocol.USHORT, [1]))
+    assert m.recvignorecount == 1
+    assert m.write_count == 0
+
+
+def test_missing_mapfile_raises():
+    with pytest.raises(ValueError):
+        canas_mapping.Mapping("no_such_mapfile.yaml", FakeLog())
+
+
+def test_shipped_rotax_skeleton_loads(database):
+    m = canas_mapping.Mapping(
+        "src/fixgw/config/canaerospace/rotax_is_map.yaml", FakeLog()
+    )
+    assert not m.input_map
+    assert not m.event_map
+    assert not any(m.interesting)
+
+
+@pytest.mark.parametrize(
+    "yaml_text",
+    [
+        # canid missing
+        """
+inputs:
+  - fixid: TACH1
+""",
+        # canid out of range
+        """
+inputs:
+  - canid: 2032
+    fixid: TACH1
+""",
+        # canid not an int
+        """
+inputs:
+  - canid: 'x'
+    fixid: TACH1
+""",
+        # unknown fixid
+        """
+inputs:
+  - canid: 300
+    fixid: NOSUCHKEY
+""",
+        # duplicate (canid, element)
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+  - canid: 300
+    fixid: PROP1
+""",
+        # bad element
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    element: 4
+""",
+        # bad converter
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    converter: furlongs
+""",
+        # bad type name
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    type: MEMID
+""",
+        # nodes not a list
+        """
+inputs:
+  - canid: 300
+    fixid: TACH1
+    nodes: 16
+""",
+        # strict_types not a bool
+        """
+strict_types: 'yes'
+inputs: []
+""",
+        # ignore_fixid_missing not a bool
+        """
+ignore_fixid_missing: 1
+inputs: []
+""",
+        # event canid outside EED range
+        """
+events:
+  - canid: 300
+    fixid: BTN1
+""",
+        # event match_code not an int
+        """
+events:
+  - canid: 16
+    fixid: BTN1
+    match_code: 'x'
+""",
+    ],
+)
+def test_validation_errors(tmp_path, database, yaml_text):
+    with pytest.raises(ValueError):
+        make_mapping(tmp_path, yaml_text)
+
+
+def test_ignore_fixid_missing_skips_entry(tmp_path, database):
+    m = make_mapping(
+        tmp_path,
+        """
+ignore_fixid_missing: true
+inputs:
+  - canid: 300
+    fixid: NOSUCHKEY
+  - canid: 301
+    fixid: TACH1
+""",
+    )
+    # The unknown fixid is inert, the good one still works
+    assert m.interesting[300] is False
+    assert m.interesting[301] is True
+    m.inputMap(msg(301, protocol.USHORT, [1200]))
+    assert database.read("TACH1")[0] == 1200
+
+
+def test_unknown_top_level_key_warns_not_fails(tmp_path, database):
+    log = FakeLog()
+    make_mapping(
+        tmp_path,
+        """
+bogus_key: 1
+inputs:
+  - canid: 300
+    fixid: TACH1
+""",
+        log=log,
+    )
+    assert any("bogus_key" in w for w in log.warnings)

--- a/tests/plugins/canaerospace/test_plugin.py
+++ b/tests/plugins/canaerospace/test_plugin.py
@@ -1,0 +1,232 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# Plugin lifecycle and virtual-bus integration tests: start the real
+# plugin against a python-can 'virtual' bus, send CANaerospace frames with
+# a plain can.Bus, and assert FIX database values and status counters.
+
+import random
+import time
+from collections import namedtuple
+
+import can
+import pytest
+
+import fixgw.plugin as plugin_base
+import fixgw.plugins.canaerospace
+from fixgw import cfg
+from fixgw.plugins.canaerospace import protocol
+from fixgw.tools import canas_sim
+
+CONFIG_DATA = """
+load: yes
+module: fixgw.plugins.canaerospace
+interface: virtual
+channel: tcan_canas
+mapfile: 'tests/config/canaerospace/map.yaml'
+node_timeout: 0.5
+CONFIGPATH: ''
+"""
+
+
+Objects = namedtuple("Objects", ["bus", "pl"])
+
+
+@pytest.fixture
+def plugin(database):
+    cc, cc_meta = cfg.from_yaml(CONFIG_DATA, metadata=True)
+    pl = fixgw.plugins.canaerospace.Plugin("canaerospace", cc, cc_meta)
+    pl.start()
+    can_bus = can.Bus(cc["channel"], interface=cc["interface"])
+    time.sleep(0.1)  # Give the plugin thread a chance to get started
+    yield Objects(bus=can_bus, pl=pl)
+    pl.stop()
+    can_bus.shutdown()
+
+
+def send(bus, canid, data):
+    msg = can.Message(is_extended_id=False, arbitration_id=canid)
+    msg.data = bytearray(data)
+    msg.dlc = len(msg.data)
+    bus.send(msg)
+
+
+def frame(node, dtype, code, values):
+    m = protocol.CanasMessage(
+        canid=300,  # placeholder, build() only uses it for range checking
+        node_id=node,
+        data_type=dtype,
+        service_code=0,
+        message_code=code,
+        values=tuple(values),
+        channel=protocol.Channel.NOD,
+    )
+    return protocol.build(m)[1]
+
+
+def wait_for(pred, timeout=2.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        if pred():
+            return True
+        time.sleep(0.01)
+    return pred()
+
+
+def test_parameter_writes_and_status(plugin, database):
+    send(plugin.bus, 200, frame(16, protocol.USHORT, 1, [2650]))
+    assert wait_for(lambda: database.read("TACH1")[0] == 2650)
+    # 310 kPa -> ~44.96 psi via the kpa2psi converter
+    send(plugin.bus, 201, frame(16, protocol.FLOAT, 2, [310.0]))
+    assert wait_for(lambda: database.read("OILP1")[0] == pytest.approx(44.96, abs=0.01))
+    # One UCHAR4 frame feeds two EGT cylinders
+    send(plugin.bus, 205, frame(16, protocol.UCHAR4, 3, [78, 80, 0, 0]))
+    assert wait_for(lambda: database.read("EGT11")[0] == pytest.approx(780.0))
+    assert database.read("EGT12")[0] == pytest.approx(800.0)
+
+    status = plugin.pl.get_status()
+    assert status["Received Frames"] == 3
+    assert status["Decoded Writes"] == 4
+    assert status["Invalid Frames"] == 0
+    assert 16 in status["Nodes Seen"]
+    assert status["Nodes Seen"][16]["frames"] == 3
+
+
+def test_ignored_invalid_unsupported_nodata(plugin, database):
+    # Unmapped Debug Service Data channel -> ignored
+    send(plugin.bus, 1900, frame(16, protocol.USHORT, 1, [1]))
+    # Unmapped NOD id -> ignored
+    send(plugin.bus, 301, frame(16, protocol.USHORT, 2, [1]))
+    # 29-bit identifier -> ignored
+    msg = can.Message(
+        is_extended_id=True,
+        arbitration_id=0x18C,
+        data=bytearray(b"\x10\x07\x00\x01\x00\x01"),
+    )
+    plugin.bus.send(msg)
+    # Mapped id, DLC < 4 -> invalid
+    send(plugin.bus, 200, b"\x10\x07\x00")
+    # Mapped id, unsupported data type -> counted, not fatal
+    send(plugin.bus, 200, bytes((0x10, protocol.MEMID, 0x00, 0x01)) + b"\x00" * 4)
+    # Mapped id, NODATA -> counted, nothing written
+    send(plugin.bus, 200, frame(16, protocol.NODATA, 4, []))
+
+    assert wait_for(lambda: plugin.pl.recvcount == 6)
+    status = plugin.pl.get_status()
+    assert status["Ignored Frames"] == 3
+    assert status["Invalid Frames"] == 1
+    assert status["Unsupported Types"] == 1
+    assert status["NoData Frames"] == 1
+    assert status["Decoded Writes"] == 0
+    assert database.read("TACH1")[0] == 0
+
+
+def test_emergency_event_latches_annunciator(plugin, database):
+    assert database.read("BTN1")[0] is False
+    # EED canid 16, any payload (match_code null)
+    send(plugin.bus, 16, frame(9, protocol.ULONG, 1, [1]))
+    assert wait_for(lambda: database.read("BTN1")[0] is True)
+    # EED canid 17 fires only on its match_code (0x12345678)
+    send(plugin.bus, 17, frame(9, protocol.ULONG, 2, [0x11111111]))
+    time.sleep(0.1)
+    assert database.read("BTN2")[0] is False
+    send(plugin.bus, 17, frame(9, protocol.ULONG, 3, [0x12345678]))
+    assert wait_for(lambda: database.read("BTN2")[0] is True)
+    status = plugin.pl.get_status()
+    assert status["Emergency Events"] == 3
+
+
+def test_sequence_gap_telltale(plugin, database):
+    send(plugin.bus, 200, frame(16, protocol.USHORT, 7, [1000]))
+    send(plugin.bus, 200, frame(16, protocol.USHORT, 8, [1100]))
+    send(plugin.bus, 200, frame(16, protocol.USHORT, 12, [1200]))  # gap
+    send(plugin.bus, 200, frame(16, protocol.USHORT, 13, [1300]))
+    assert wait_for(lambda: database.read("TACH1")[0] == 1300)
+    status = plugin.pl.get_status()
+    assert status["Sequence Gaps"] == 1
+    # The gap never gated decoding
+    assert status["Decoded Writes"] == 4
+
+
+def test_node_failover_over_the_bus(plugin, database):
+    # OILT1 (canid 202) prefers node 16 over node 17; node_timeout 0.5s
+    send(plugin.bus, 202, frame(16, protocol.FLOAT, 1, [333.15]))  # 60 C
+    assert wait_for(lambda: database.read("OILT1")[0] == pytest.approx(60.0, abs=0.01))
+    send(plugin.bus, 202, frame(17, protocol.FLOAT, 1, [343.15]))  # blocked
+    time.sleep(0.1)
+    assert database.read("OILT1")[0] == pytest.approx(60.0, abs=0.01)
+    time.sleep(0.6)  # let node 16 go stale
+    send(plugin.bus, 202, frame(17, protocol.FLOAT, 2, [343.15]))  # 70 C
+    assert wait_for(lambda: database.read("OILT1")[0] == pytest.approx(70.0, abs=0.01))
+
+
+def test_fuzz_soak_never_kills_the_thread(plugin, database):
+    # Deterministic hostile traffic: random ids, DLCs and payloads
+    rng = random.Random(42)
+    for _ in range(500):
+        canid, data = canas_sim.fuzz_message(rng)
+        send(plugin.bus, canid, data)
+    assert wait_for(lambda: plugin.pl.recvcount >= 500, timeout=5.0)
+    assert plugin.pl.thread.is_alive()
+    # Status must remain coherent (all counters accounted, no exception)
+    status = plugin.pl.get_status()
+    total = (
+        status["Ignored Frames"]
+        + status["Invalid Frames"]
+        + status["Unsupported Types"]
+        + status["NoData Frames"]
+        + status["Decoded Writes"]
+        + status["Error Frames"]
+    )
+    assert total >= 0  # smoke: get_status() itself did not blow up
+
+
+def test_sim_default_script_parses_and_counts():
+    codes = {}
+    frames = list(canas_sim.script_messages(canas_sim.DEFAULT_SCRIPT, codes))
+    assert len(frames) == len(canas_sim.DEFAULT_SCRIPT)
+    for canid, data in frames:
+        protocol.parse(canid, data)  # must not raise
+    # Message codes increment per (canid, node) and wrap at 256
+    frames2 = list(canas_sim.script_messages(canas_sim.DEFAULT_SCRIPT, codes))
+    for (_, d1), (_, d2) in zip(frames, frames2):
+        assert d2[3] == (d1[3] + 1) % 256
+
+
+def test_missing_mapfile_raises(database):
+    bad = CONFIG_DATA.replace("tests/config/canaerospace/map.yaml", "no_such_map.yaml")
+    cc, cc_meta = cfg.from_yaml(bad, metadata=True)
+    with pytest.raises(ValueError):
+        fixgw.plugins.canaerospace.Plugin("canaerospace", cc, cc_meta)
+
+
+def test_stop_failure_raises_pluginfail(database):
+    cc, cc_meta = cfg.from_yaml(CONFIG_DATA, metadata=True)
+    pl = fixgw.plugins.canaerospace.Plugin("canaerospace", cc, cc_meta)
+
+    class StuckThread:
+        def stop(self):
+            pass
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout):
+            pass
+
+    pl.thread = StuckThread()
+    with pytest.raises(plugin_base.PluginFail):
+        pl.stop()

--- a/tests/plugins/canaerospace/test_protocol.py
+++ b/tests/plugins/canaerospace/test_protocol.py
@@ -1,0 +1,202 @@
+#  Copyright (c) 2026 MakerPlane contributors
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+# Pure decode tests for the CANaerospace protocol module: hex vectors in,
+# expected CanasMessage fields out.  Data-type codes and identifier ranges
+# follow the CANaerospace V1.7 tables (cross-verified against the
+# CanasStandardDataTypeID / CanasMessageTypeID enums in Pavel Kirienko's
+# reference C implementation).
+
+import struct
+
+import pytest
+
+from fixgw.plugins.canaerospace import protocol
+
+
+def string2data(s):
+    s = s.replace(" ", "")
+    b = bytearray()
+    for x in range(0, len(s), 2):
+        b.append(int(s[x : x + 2], 16))  # noqa: E203
+    return b
+
+
+# (arbitration_id, frame hex, expected data_type, expected values)
+# Header in every vector: node 0x10 (16), service code 0x00, message code 0x07.
+DECODE_VECTORS = [
+    (300, "10 00 00 07", protocol.NODATA, ()),
+    (300, "10 01 00 07 DEADBEEF", protocol.ERROR, (0xDEADBEEF,)),
+    (300, "10 02 00 07 436A8000", protocol.FLOAT, (234.5,)),
+    (300, "10 02 00 07 BFC00000", protocol.FLOAT, (-1.5,)),
+    (300, "10 03 00 07 80000000", protocol.LONG, (-2147483648,)),
+    (300, "10 03 00 07 7FFFFFFF", protocol.LONG, (2147483647,)),
+    (300, "10 04 00 07 80000000", protocol.ULONG, (2147483648,)),
+    (300, "10 05 00 07 A5A5A5A5", protocol.BLONG, (0xA5A5A5A5,)),
+    (300, "10 06 00 07 FFF6", protocol.SHORT, (-10,)),
+    (300, "10 06 00 07 8000", protocol.SHORT, (-32768,)),
+    (300, "10 07 00 07 FFF6", protocol.USHORT, (65526,)),
+    (300, "10 08 00 07 8001", protocol.BSHORT, (0x8001,)),
+    (300, "10 09 00 07 80", protocol.CHAR, (-128,)),
+    (300, "10 0A 00 07 FF", protocol.UCHAR, (255,)),
+    (300, "10 0B 00 07 AA", protocol.BCHAR, (0xAA,)),
+    (300, "10 0C 00 07 FFFF0001", protocol.SHORT2, (-1, 1)),
+    (300, "10 0D 00 07 FFFF0001", protocol.USHORT2, (65535, 1)),
+    (300, "10 0E 00 07 12345678", protocol.BSHORT2, (0x1234, 0x5678)),
+    (300, "10 0F 00 07 807FFF00", protocol.CHAR4, (-128, 127, -1, 0)),
+    (300, "10 10 00 07 807FFF00", protocol.UCHAR4, (128, 127, 255, 0)),
+    (300, "10 11 00 07 01020304", protocol.BCHAR4, (1, 2, 3, 4)),
+    (300, "10 12 00 07 FE02", protocol.CHAR2, (-2, 2)),
+    (300, "10 13 00 07 FE02", protocol.UCHAR2, (254, 2)),
+    (300, "10 14 00 07 ABCD", protocol.BCHAR2, (0xAB, 0xCD)),
+    (300, "10 1A 00 07 FF0001", protocol.CHAR3, (-1, 0, 1)),
+    (300, "10 1B 00 07 FF0001", protocol.UCHAR3, (255, 0, 1)),
+    (300, "10 1C 00 07 010203", protocol.BCHAR3, (1, 2, 3)),
+]
+
+
+@pytest.mark.parametrize("canid,hexstr,dtype,values", DECODE_VECTORS)
+def test_decode_vectors(canid, hexstr, dtype, values):
+    msg = protocol.parse(canid, string2data(hexstr))
+    assert msg.canid == canid
+    assert msg.node_id == 0x10
+    assert msg.data_type == dtype
+    assert msg.service_code == 0x00
+    assert msg.message_code == 0x07
+    assert msg.channel is protocol.Channel.NOD
+    assert len(msg.values) == len(values)
+    for got, want in zip(msg.values, values):
+        assert got == pytest.approx(want)
+
+
+@pytest.mark.parametrize("canid,hexstr,dtype,values", DECODE_VECTORS)
+def test_build_round_trip(canid, hexstr, dtype, values):
+    msg = protocol.parse(canid, string2data(hexstr))
+    out_id, out_data = protocol.build(msg)
+    assert out_id == canid
+    assert out_data == bytes(string2data(hexstr))
+
+
+def test_float_matches_struct():
+    # Independent anchor: the FLOAT wire format is IEEE-754 single,
+    # big-endian, exactly struct's '>f'.
+    payload = struct.pack(">f", 42.42)
+    msg = protocol.parse(300, b"\x10\x02\x00\x07" + payload)
+    assert msg.values[0] == pytest.approx(42.42, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "canid,channel",
+    [
+        (0, protocol.Channel.EED),
+        (127, protocol.Channel.EED),
+        (128, protocol.Channel.NSH),
+        (199, protocol.Channel.NSH),
+        (200, protocol.Channel.UDH),
+        (299, protocol.Channel.UDH),
+        (300, protocol.Channel.NOD),
+        (1799, protocol.Channel.NOD),
+        (1800, protocol.Channel.UDL),
+        (1899, protocol.Channel.UDL),
+        (1900, protocol.Channel.DSD),
+        (1999, protocol.Channel.DSD),
+        (2000, protocol.Channel.NSL),
+        (2031, protocol.Channel.NSL),
+    ],
+)
+def test_channel_distribution(canid, channel):
+    assert protocol.channel_for(canid) is channel
+
+
+def test_channel_out_of_range():
+    with pytest.raises(protocol.CanasDecodeError):
+        protocol.channel_for(2032)
+
+
+@pytest.mark.parametrize(
+    "canid,hexstr",
+    [
+        (300, "10 02 00"),  # DLC < 4
+        (300, "10 02 00 07 43 6A 80 00 00"),  # DLC > 8
+        (2032, "10 02 00 07 436A8000"),  # canid past NSL
+        (300, "10 02 00 07 436A"),  # FLOAT payload too short
+        (300, "10 06 00 07 FFF60000"),  # SHORT payload too long
+        (300, "10 00 00 07 01"),  # NODATA with payload
+    ],
+)
+def test_decode_errors(canid, hexstr):
+    with pytest.raises(protocol.CanasDecodeError):
+        protocol.parse(canid, string2data(hexstr))
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        protocol.MEMID,
+        protocol.CHKSUM,
+        protocol.ACHAR,
+        protocol.ACHAR2,
+        protocol.ACHAR4,
+        protocol.ACHAR3,
+        protocol.DOUBLEH,
+        protocol.DOUBLEL,
+        100,  # user-defined
+        255,
+        32,  # reserved
+    ],
+)
+def test_unsupported_types(dtype):
+    frame = bytes((0x10, dtype, 0x00, 0x07)) + b"\x00\x00\x00\x00"
+    with pytest.raises(protocol.CanasUnsupportedType):
+        protocol.parse(300, frame)
+    # Unsupported is a subclass of the general decode error so callers may
+    # catch either.
+    assert issubclass(protocol.CanasUnsupportedType, protocol.CanasDecodeError)
+
+
+def test_build_rejects_unsupported_type():
+    msg = protocol.CanasMessage(
+        canid=300,
+        node_id=1,
+        data_type=protocol.MEMID,
+        service_code=0,
+        message_code=0,
+        values=(0,),
+        channel=protocol.Channel.NOD,
+    )
+    with pytest.raises(protocol.CanasUnsupportedType):
+        protocol.build(msg)
+
+
+def test_build_rejects_unencodable_values():
+    msg = protocol.CanasMessage(
+        canid=300,
+        node_id=1,
+        data_type=protocol.USHORT,
+        service_code=0,
+        message_code=0,
+        values=(70000,),  # does not fit uint16
+        channel=protocol.Channel.NOD,
+    )
+    with pytest.raises(protocol.CanasDecodeError):
+        protocol.build(msg)
+
+
+def test_type_names():
+    assert protocol.type_name(protocol.FLOAT) == "FLOAT"
+    assert protocol.type_name(protocol.MEMID) == "MEMID"
+    assert protocol.type_name(150) == "UDEF150"
+    assert protocol.type_name(40) == "RESERVED40"


### PR DESCRIPTION
## What / why

Implements the CANaerospace input bridge specced in `pyEfis/docs/fixgw_canaerospace_in_spec.md` (2026-07-05): a listen-only plugin that decodes CANaerospace V1.7 frames (motivating device: Rotax 912iS/915iS ECU) and writes mapped values into the FIX database. CAN-FIX stays the native protocol; CANaerospace is consumed as a federated input. The plugin never transmits — not even Node Service replies.

New package `src/fixgw/plugins/canaerospace/` (three modules per the spec's architecture):
- `protocol.py` — pure, stdlib-only decode/build (hex-vector testable, reused by the simulator)
- `mapping.py` — YAML mapfile -> pre-resolved dispatch, canfix closure pattern, `interesting[]` hot-path reject
- `__init__.py` — canfix-style lifecycle (ThreadSafeBus, recv(1.0) loop, stop() copied verbatim incl. PluginFail)

Plus: `config/connections/canaerospace.yaml` (ships `load: no`), the fully-commented-out Rotax mapfile skeleton, `tools/canas_sim.py` (script + fuzz modes, smoke-tested standalone), `doc/plugins/canaerospace.rst`, and 126 tests.

## Design choices

- **Wire type is authoritative; mapfile `type:` is an expectation check.** Mismatches are counted (and rate-limit-logged) but still decoded unless `strict_types: true` — a Rotax firmware type change stays visible without silently corrupting values (spec 6.2).
- **Node priority (dual-lane failover)** is per-entry state: the sender's liveness is always recorded, then the frame is written only if every higher-priority node has been quiet for `node_timeout` (spec 6.3). No lane annunciation in v1; FIX `tol` handles both-lanes-quiet.
- **ERROR frames set the item's `fail` flag without disturbing the value**; the next good value clears it (spec 6.4). Good writes are plain value writes, so other flag writers are not stomped.
- **EED frames are handled from the raw frame** (log + count + event match) *before* parse, so a malformed emergency frame is still surfaced.
- **Unsupported data types are a distinct exception subclass** so status separates "Unsupported Types" from "Invalid Frames".
- Duplicate `(canid, element)` mapfile pairs are load-time errors with file/line via `cfg.message`; unknown top-level keys warn, don't fail.

## Self-review notes (scrutinize these)

1. **Data-type/ID tables were verified against Kirienko's C reference enums (verbatim, order-counted), not the canas_17.pdf itself** — the PDF fetch returned no extractable text in this environment. The spec names the PDF as tie-breaker and asks for section-number citations in code comments; `protocol.py` cites the tables by name + the C-library cross-check instead. A 5-minute human pass against the PDF (data-type table + identifier distribution + a worked-example vector for the test suite's provenance anchor) is the remaining verification step. Related: the spec's test item "one vector transcribed from a worked example in canas_17.pdf" is NOT present; `test_float_matches_struct` anchors FLOAT to IEEE-754 `>f` independently instead.
2. **ERROR handling only fires for the element-0 entry of a canid** (ERROR frames carry no element addressing). If a multi-element canid should fail ALL its mapped fixids on ERROR, that's a one-line change — the spec (6.4) says "the mapped fixid (canid, element=0)", which is what's implemented.
3. **EED frames are logged at WARNING unconditionally, per spec 6.5** ("always logged"). A stuck sender spamming an emergency id will be noisy in the log. Deliberate (emergencies should be loud), but worth a think.
4. `canas_sim`'s default script uses **placeholder canids in the User-Defined High range**, labeled as such — the spec wanted "the Rotax skeleton parameters with plausible values", and since the skeleton ships with no real IDs, placeholders were the only non-inventing option.

## Test evidence

- `pytest tests/plugins/canaerospace --no-cov` — **126 passed** (Windows, Py3.13 venv; virtual bus only, no socketcan).
- Full suite minus `end_to_end`: **761 passed, 9 failed** — the same 9 fail on clean `dev` with this branch's files stashed (rtl_433 snap path, test_cfg, test_process, test_server; pre-existing Windows-environmental, Linux CI is authority).
- `canas_sim` smoke: 140 script frames + 96 fuzz frames sent standalone; in-suite 500-frame deterministic fuzz soak leaves the thread alive and status coherent.
- Black: all new files formatted (`black --check` clean).

## Spec deviations

- Section-number PDF citations in `protocol.py` comments: see self-review note 1.
- `doc/plugins/toc.rst` untouched — it already globs `*`.
- Acceptance item "drives TACH1/OILP1 visibly in fixgwc and pyEfis on the Windows twin" was not run as a live GUI session; the virtual-bus integration tests assert the same database writes end-to-end. A desk demo is a 2-minute follow-up: `canas_sim --interface virtual` + a test mapfile.

## Out of scope, noticed

- `fixgw.plugins.canfix.stop()` (and this plugin, which copies it) never calls `bus.shutdown()`; python-can prints 'VirtualBus was not properly shut down' in tests. Cosmetic, pre-existing pattern.
- The sibling `fixgw_dronecan_in_spec.md` remains unimplemented (separate backlog item).
- Both bridge specs are still untracked files in the pyEfis repo; they should be committed somewhere durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)